### PR TITLE
Fix environment variable for API URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://localhost:8080
+VITE_API_URL=http://localhost:8080

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8080';
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
 const authService = {
     login: async (email, password) => {


### PR DESCRIPTION
## Summary
- use Vite env `import.meta.env.VITE_API_URL` in `authService`
- rename `.env` variable to `VITE_API_URL`

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68887f0a23448320a88d62c5d3aa47c5