### PR TITLE
Fix logout failing when API rejects request

### DIFF
--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -18,11 +18,20 @@ const authService = {
 
     logout: async () => {
         const token = localStorage.getItem('accessToken');
-        await axios.post(`${API_URL}/auth/logout`, {}, {
-            headers: { Authorization: `Bearer ${token}` }
-        });
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('refreshToken');
+        try {
+            if (token) {
+                await axios.post(
+                    `${API_URL}/auth/logout`,
+                    {},
+                    { headers: { Authorization: `Bearer ${token}` } }
+                );
+            }
+        } catch (err) {
+            console.error('Failed to logout from API:', err);
+        } finally {
+            localStorage.removeItem('accessToken');
+            localStorage.removeItem('refreshToken');
+        }
     }
 };
 


### PR DESCRIPTION
## Summary
- clear tokens even if `/auth/logout` returns an error
- log the API error for debugging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68889942505c8320a151c1c34839d9c6