### PR TITLE
Fix token usage for upcoming events request

### DIFF
--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -22,8 +22,10 @@ const eventService = {
     },
 
     getUpcomingEvents: async () => {
-        const now = new Date().toISOString();
-        const response = await axios.get(`${API_URL}/events/upcoming?after=${encodeURIComponent(now)}`);
+        const now = new Date().toISOString().replace('Z', '');
+        const response = await axios.get(`${API_URL}/events/upcoming?after=${encodeURIComponent(now)}`, {
+            headers: getAuthHeaders()
+        });
         return response.data;
     },
 


### PR DESCRIPTION
## Summary
- include authorization header in the `getUpcomingEvents` call
- send ISO datetime without timezone suffix so backend accepts it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68889e4c84648320945b0f17329d2dfa