### PR TITLE
Fix login and logout redirects

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import AuthPage from './pages/AuthPage';
 import Dashboard from './pages/Dashboard';
@@ -7,18 +7,35 @@ import EventsPage from './pages/EventsPage';
 import ProfilePage from './pages/ProfilePage';
 
 function App() {
-  const isAuthenticated = localStorage.getItem('accessToken');
+  const [isAuthenticated, setIsAuthenticated] = useState(
+    !!localStorage.getItem('accessToken')
+  );
+
+  const handleLogin = () => setIsAuthenticated(true);
+  const handleLogout = () => setIsAuthenticated(false);
 
   return (
     <Router>
       <Routes>
         <Route
           path="/"
-          element={isAuthenticated ? <Navigate to="/dashboard" /> : <AuthPage />}
+          element={
+            isAuthenticated ? (
+              <Navigate to="/dashboard" />
+            ) : (
+              <AuthPage onLogin={handleLogin} />
+            )
+          }
         />
         <Route
           path="/dashboard"
-          element={isAuthenticated ? <Dashboard /> : <Navigate to="/" />}
+          element={
+            isAuthenticated ? (
+              <Dashboard onLogout={handleLogout} />
+            ) : (
+              <Navigate to="/" />
+            )
+          }
         />
         <Route
           path="/calendar"

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -19,7 +19,7 @@ import authService from '../services/authService';
 import { validateUBBEmail } from '../utils/validators';
 import { UBB_COLORS } from '../styles/colors';
 
-const AuthPage = () => {
+const AuthPage = ({ onLogin }) => {
     const navigate = useNavigate();
     const [tab, setTab] = useState(0); // 0 login, 1 register
     const [showPassword, setShowPassword] = useState(false);
@@ -62,6 +62,7 @@ const AuthPage = () => {
             const data = await authService.login(loginData.email, loginData.password);
             localStorage.setItem('accessToken', data.accessToken);
             localStorage.setItem('refreshToken', data.refreshToken);
+            if (onLogin) onLogin();
             setSuccess('¡Inicio de sesión exitoso! Redirigiendo...');
             setTimeout(() => {
                 navigate('/dashboard');
@@ -111,6 +112,7 @@ const AuthPage = () => {
             const data = await authService.register(dataToSend);
             localStorage.setItem('accessToken', data.accessToken);
             localStorage.setItem('refreshToken', data.refreshToken);
+            if (onLogin) onLogin();
             setSuccess('¡Registro exitoso! Redirigiendo...');
             setTimeout(() => {
                 navigate('/dashboard');

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -11,12 +11,13 @@ import { Calendar, List, User, LogOut } from 'lucide-react';
 import authService from '../services/authService';
 import { UBB_COLORS } from '../styles/colors';
 
-const Dashboard = () => {
+const Dashboard = ({ onLogout }) => {
     const navigate = useNavigate();
 
     const handleLogout = async () => {
         try {
             await authService.logout();
+            if (onLogout) onLogout();
             navigate('/');
         } catch (error) {
             console.error('Error al cerrar sesión:', error);


### PR DESCRIPTION
## Summary
- track authentication state in `App` using state
- notify `App` when login/register or logout occurs
- ensure redirects to `/dashboard` after login and `/` after logout

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68889f9a23f48320adb9b9b6f4d4efc7