### PR TITLE
Fix event mapping and role detection

### DIFF
--- a/src/pages/CalendarPage.jsx
+++ b/src/pages/CalendarPage.jsx
@@ -2,14 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Container, Typography, Card, CardContent } from '@mui/material';
 import eventService from '../services/eventService';
 import { UBB_COLORS } from '../styles/colors';
-
-const parseJwt = (token) => {
-    try {
-        return JSON.parse(atob(token.split('.')[1]));
-    } catch (e) {
-        return null;
-    }
-};
+import { getUserIdFromToken } from '../utils/auth';
 
 const CalendarPage = () => {
     const [events, setEvents] = useState([]);
@@ -18,8 +11,7 @@ const CalendarPage = () => {
         const fetchEvents = async () => {
             const token = localStorage.getItem('accessToken');
             if (!token) return;
-            const payload = parseJwt(token);
-            const userId = payload?.id || payload?.userId || payload?.sub;
+            const userId = getUserIdFromToken(token);
             if (!userId) return;
             try {
                 const toAttend = await eventService.getEventsToAttend(userId);

--- a/src/pages/EventsPage.jsx
+++ b/src/pages/EventsPage.jsx
@@ -18,14 +18,7 @@ import {
 } from '@mui/material';
 import eventService from '../services/eventService';
 import { UBB_COLORS } from '../styles/colors';
-
-const parseJwt = (token) => {
-    try {
-        return JSON.parse(atob(token.split('.')[1]));
-    } catch (e) {
-        return null;
-    }
-};
+import { getUserIdFromToken, getRoleFromToken } from '../utils/auth';
 
 const EventCard = ({
     event,
@@ -48,7 +41,7 @@ const EventCard = ({
                 {new Date(event.fechaFin).toLocaleString()}
             </Typography>
             <Typography variant="body2">{event.lugar}</Typography>
-            {event.estado === 'PENDIENTE' && (
+            {event.estadoValidacion === 'PENDIENTE' && (
                 <Typography variant="caption" color="orange">
                     Pendiente de aprobación
                 </Typography>
@@ -101,7 +94,7 @@ const EventsPage = () => {
         fechaFin: '',
         lugar: '',
         aforoMax: '',
-        publico: true
+        visibilidad: true
     });
     const [editingId, setEditingId] = useState(null);
 
@@ -109,9 +102,8 @@ const EventsPage = () => {
         const load = async () => {
             try {
                 const token = localStorage.getItem('accessToken');
-                const payload = parseJwt(token);
-                const uid = payload?.id || payload?.userId || payload?.sub;
-                const userRole = payload?.role || payload?.roles?.[0];
+                const uid = getUserIdFromToken(token);
+                const userRole = getRoleFromToken(token);
                 setRole(userRole);
                 setUserId(uid);
 
@@ -152,14 +144,14 @@ const EventsPage = () => {
 
     const handleCreateOrUpdate = async () => {
         try {
-            const data = { ...formData, aforoMax: Number(formData.aforoMax), publico: formData.publico };
+            const data = { ...formData, aforoMax: Number(formData.aforoMax), visibilidad: formData.visibilidad };
             if (editingId) {
                 await eventService.updateEvent({ ...data, id: editingId });
             } else {
                 await eventService.createEvent(data);
             }
             setFormOpen(false);
-            setFormData({ titulo: '', descripcion: '', fechaInicio: '', fechaFin: '', lugar: '', aforoMax: '', publico: true });
+            setFormData({ titulo: '', descripcion: '', fechaInicio: '', fechaFin: '', lugar: '', aforoMax: '', visibilidad: true });
             setEditingId(null);
             await refreshAll();
         } catch (err) {
@@ -218,7 +210,7 @@ const EventsPage = () => {
             fechaFin: ev.fechaFin,
             lugar: ev.lugar,
             aforoMax: ev.aforoMax,
-            publico: ev.publico !== false
+            visibilidad: ev.visibilidad !== false
         });
         setFormOpen(true);
     };
@@ -310,8 +302,8 @@ const EventsPage = () => {
                     <FormControlLabel
                         control={
                             <Checkbox
-                                checked={formData.publico}
-                                onChange={(e) => setFormData({ ...formData, publico: e.target.checked })}
+                                checked={formData.visibilidad}
+                                onChange={(e) => setFormData({ ...formData, visibilidad: e.target.checked })}
                                 color="primary"
                             />
                         }

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -11,14 +11,7 @@ import {
 import { Users, Trophy, CalendarCheck } from 'lucide-react';
 import { UBB_COLORS } from '../styles/colors';
 import userService from '../services/userService';
-
-const parseJwt = (token) => {
-    try {
-        return JSON.parse(atob(token.split('.')[1]));
-    } catch {
-        return null;
-    }
-};
+import { getUserIdFromToken } from '../utils/auth';
 
 const ProfilePage = () => {
     const [user, setUser] = useState(null);
@@ -29,8 +22,7 @@ const ProfilePage = () => {
         const load = async () => {
             const token = localStorage.getItem('accessToken');
             if (!token) return;
-            const payload = parseJwt(token);
-            const userId = payload?.id || payload?.userId || payload?.sub;
+            const userId = getUserIdFromToken(token);
             if (!userId) return;
             try {
                 const usr = await userService.getUser(userId);

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,34 @@
+export const parseJwt = (token) => {
+    if (!token) return null;
+    try {
+        return JSON.parse(atob(token.split('.')[1]));
+    } catch {
+        return null;
+    }
+};
+
+export const getUserIdFromToken = (token) => {
+    const payload = parseJwt(token);
+    return payload?.id || payload?.userId || payload?.sub || null;
+};
+
+export const getRoleFromToken = (token) => {
+    const payload = parseJwt(token);
+    if (!payload) return '';
+    return (
+        payload.role ||
+        payload.rol ||
+        (Array.isArray(payload.roles)
+            ? typeof payload.roles[0] === 'string'
+                ? payload.roles[0]
+                : payload.roles[0]?.authority
+            : null) ||
+        (Array.isArray(payload.authorities)
+            ? typeof payload.authorities[0] === 'string'
+                ? payload.authorities[0]
+                : payload.authorities[0]?.authority
+            : null) ||
+        payload.authority ||
+        ''
+    );
+};


### PR DESCRIPTION
## Summary
- add auth helpers to parse JWT tokens
- use new helpers in pages
- map event fields `visibilidad` and `estadoValidacion`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888a415b6c483208bf52c69826aabd9