### PR TITLE
Handle unauthorized requests gracefully

### DIFF
--- a/src/pages/EventsPage.jsx
+++ b/src/pages/EventsPage.jsx
@@ -109,6 +109,7 @@ const EventsPage = () => {
         const load = async () => {
             try {
                 const token = localStorage.getItem('accessToken');
+                if (!token) return;
                 const payload = parseJwt(token);
                 const uid = payload?.id || payload?.userId || payload?.sub;
                 const userRole = payload?.role || payload?.roles?.[0];

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,10 +1,8 @@
-import axios from 'axios';
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+import axiosInstance from './axiosInstance';
 
 const authService = {
     login: async (email, password) => {
-        const response = await axios.post(`${API_URL}/auth/login`, {
+        const response = await axiosInstance.post('/auth/login', {
             email,
             password
         });
@@ -12,7 +10,7 @@ const authService = {
     },
 
     register: async (userData) => {
-        const response = await axios.post(`${API_URL}/auth/register`, userData);
+        const response = await axiosInstance.post('/auth/register', userData);
         return response.data;
     },
 
@@ -20,11 +18,7 @@ const authService = {
         const token = localStorage.getItem('accessToken');
         try {
             if (token) {
-                await axios.post(
-                    `${API_URL}/auth/logout`,
-                    {},
-                    { headers: { Authorization: `Bearer ${token}` } }
-                );
+                await axiosInstance.post('/auth/logout');
             }
         } catch (err) {
             console.error('Failed to logout from API:', err);

--- a/src/services/axiosInstance.js
+++ b/src/services/axiosInstance.js
@@ -1,0 +1,34 @@
+import axios from 'axios';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+const instance = axios.create({
+    baseURL: API_URL
+});
+
+instance.interceptors.request.use((config) => {
+    const token = localStorage.getItem('accessToken');
+    if (token) {
+        config.headers = {
+            ...config.headers,
+            Authorization: `Bearer ${token}`
+        };
+    }
+    return config;
+});
+
+instance.interceptors.response.use(
+    (response) => response,
+    (error) => {
+        if (error.response && error.response.status === 401) {
+            localStorage.removeItem('accessToken');
+            localStorage.removeItem('refreshToken');
+            if (typeof window !== 'undefined' && window.location.pathname !== '/') {
+                window.location.href = '/';
+            }
+        }
+        return Promise.reject(error);
+    }
+);
+
+export default instance;

--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -1,91 +1,66 @@
-import axios from 'axios';
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
-
-const getAuthHeaders = () => {
-    const token = localStorage.getItem('accessToken');
-    return token ? { Authorization: `Bearer ${token}` } : {};
-};
+import axiosInstance from './axiosInstance';
 
 const eventService = {
     getEventsToAttend: async (userId) => {
-        const response = await axios.get(`${API_URL}/users/${userId}/to-attend`, {
-            headers: getAuthHeaders()
-        });
+        const response = await axiosInstance.get(`/users/${userId}/to-attend`);
         return response.data;
     },
     getEventsByIds: async (ids) => {
-        const response = await axios.get(`${API_URL}/events?ids=${ids.join(',')}`, {
-            headers: getAuthHeaders()
+        const response = await axiosInstance.get(`/events`, {
+            params: { ids: ids.join(',') }
         });
         return response.data;
     },
 
     getUpcomingEvents: async () => {
         const now = new Date().toISOString().replace('Z', '');
-        const response = await axios.get(`${API_URL}/events/upcoming?after=${encodeURIComponent(now)}`, {
-            headers: getAuthHeaders()
+        const response = await axiosInstance.get(`/events/upcoming`, {
+            params: { after: now }
         });
         return response.data;
     },
 
     getEventsByCreator: async (userId) => {
-        const response = await axios.get(`${API_URL}/events/creator/${userId}`, {
-            headers: getAuthHeaders()
-        });
+        const response = await axiosInstance.get(`/events/creator/${userId}`);
         return response.data;
     },
 
     createEvent: async (eventData) => {
-        const response = await axios.post(`${API_URL}/events`, eventData, {
-            headers: getAuthHeaders()
-        });
+        const response = await axiosInstance.post(`/events`, eventData);
         return response.data;
     },
 
     updateEvent: async (eventData) => {
-        const response = await axios.put(`${API_URL}/events`, eventData, {
-            headers: getAuthHeaders()
-        });
+        const response = await axiosInstance.put(`/events`, eventData);
         return response.data;
     },
 
     deleteEvent: async (eventId) => {
-        const response = await axios.delete(`${API_URL}/events/${eventId}`, {
-            headers: getAuthHeaders()
-        });
+        const response = await axiosInstance.delete(`/events/${eventId}`);
         return response.data;
     },
 
     getPendingEvents: async () => {
-        const response = await axios.get(`${API_URL}/events/pending`, {
-            headers: getAuthHeaders()
-        });
+        const response = await axiosInstance.get(`/events/pending`);
         return response.data;
     },
 
     approveEvent: async (eventId) => {
-        const response = await axios.post(`${API_URL}/events/${eventId}/approve`, {}, {
-            headers: getAuthHeaders()
-        });
+        const response = await axiosInstance.post(`/events/${eventId}/approve`);
         return response.data;
     },
 
     registerForEvent: async (eventId, userId) => {
-        const response = await axios.post(`${API_URL}/registrations`, {
+        const response = await axiosInstance.post(`/registrations`, {
             id: { eventId, userId }
-        }, {
-            headers: getAuthHeaders()
         });
         return response.data;
     },
 
     cancelRegistration: async (eventId, userId) => {
-        const response = await axios.post(`${API_URL}/registrations/cancel`, {
+        const response = await axiosInstance.post(`/registrations/cancel`, {
             eventId,
             userId
-        }, {
-            headers: getAuthHeaders()
         });
         return response.data;
     }

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,23 +1,16 @@
-import axios from 'axios';
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
-
-const getAuthHeaders = () => {
-    const token = localStorage.getItem('accessToken');
-    return token ? { Authorization: `Bearer ${token}` } : {};
-};
+import axiosInstance from './axiosInstance';
 
 const userService = {
     getUser: async (id) => {
-        const res = await axios.get(`${API_URL}/users/${id}`, { headers: getAuthHeaders() });
+        const res = await axiosInstance.get(`/users/${id}`);
         return res.data;
     },
     getSummary: async (id) => {
-        const res = await axios.get(`${API_URL}/users/${id}/summary`, { headers: getAuthHeaders() });
+        const res = await axiosInstance.get(`/users/${id}/summary`);
         return res.data;
     },
     getTrophies: async (ids) => {
-        const res = await axios.get(`${API_URL}/trophies?ids=${ids.join(',')}`, { headers: getAuthHeaders() });
+        const res = await axiosInstance.get(`/trophies`, { params: { ids: ids.join(',') } });
         return res.data;
     }
 };


### PR DESCRIPTION
## Summary
- create a shared axios instance with interceptors
- use axios instance in services
- early return in events page when no token is available

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888a68ca9448320a4814e0b47fa6aff