### PR TITLE
Fix events page parseJwt error

### DIFF
--- a/src/pages/EventsPage.jsx
+++ b/src/pages/EventsPage.jsx
@@ -103,7 +103,6 @@ const EventsPage = () => {
             try {
                 const token = localStorage.getItem('accessToken');
                 if (!token) return;
-                const payload = parseJwt(token);
                 const uid = getUserIdFromToken(token);
                 const userRole = getRoleFromToken(token);
                 setRole(userRole);


### PR DESCRIPTION
## Summary
- remove unused `parseJwt` reference from `EventsPage` to stop runtime error

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888a86f1f0c832080c4b23e96249206