### PR TITLE
Fix upcoming events request date format

### DIFF
--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -13,7 +13,11 @@ const eventService = {
     },
 
     getUpcomingEvents: async () => {
-        const now = new Date().toISOString().replace('Z', '');
+        // Backend expects the 'after' parameter without timezone information or
+        // milliseconds. `toISOString()` returns a string with milliseconds,
+        // which some backends fail to parse correctly. We therefore strip the
+        // milliseconds portion.
+        const now = new Date().toISOString().split('.')[0];
         const response = await axiosInstance.get(`/events/upcoming`, {
             params: { after: now }
         });


### PR DESCRIPTION
## Summary
- ensure `getUpcomingEvents` sends datetime without milliseconds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68891a3ff508832091c70112bf9cc088