### PR TITLE
Fix auth redirect on slow EventsPage load

### DIFF
--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,4 +1,10 @@
 import axiosInstance from './axiosInstance';
+import axios from 'axios';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+// Use a raw axios instance without interceptors for refresh flow
+const rawAxios = axios.create({ baseURL: API_URL });
 
 const authService = {
     login: async (email, password) => {
@@ -26,6 +32,15 @@ const authService = {
             localStorage.removeItem('accessToken');
             localStorage.removeItem('refreshToken');
         }
+    },
+
+    refreshToken: async () => {
+        const refreshToken = localStorage.getItem('refreshToken');
+        if (!refreshToken) {
+            throw new Error('No refresh token');
+        }
+        const response = await rawAxios.post('/auth/refresh', { refreshToken });
+        return response.data;
     }
 };
 

--- a/src/services/axiosInstance.js
+++ b/src/services/axiosInstance.js
@@ -1,10 +1,25 @@
 import axios from 'axios';
+import authService from './authService';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
 const instance = axios.create({
     baseURL: API_URL
 });
+
+let isRefreshing = false;
+let refreshQueue = [];
+
+const processQueue = (error, token = null) => {
+    refreshQueue.forEach((prom) => {
+        if (error) {
+            prom.reject(error);
+        } else {
+            prom.resolve(token);
+        }
+    });
+    refreshQueue = [];
+};
 
 instance.interceptors.request.use((config) => {
     const token = localStorage.getItem('accessToken');
@@ -19,12 +34,52 @@ instance.interceptors.request.use((config) => {
 
 instance.interceptors.response.use(
     (response) => response,
-    (error) => {
-        if (error.response && error.response.status === 401) {
-            localStorage.removeItem('accessToken');
-            localStorage.removeItem('refreshToken');
-            if (typeof window !== 'undefined' && window.location.pathname !== '/') {
-                window.location.href = '/';
+    async (error) => {
+        const originalRequest = error.config;
+        if (error.response && error.response.status === 401 && !originalRequest._retry) {
+            const refreshToken = localStorage.getItem('refreshToken');
+            if (refreshToken) {
+                if (isRefreshing) {
+                    return new Promise((resolve, reject) => {
+                        refreshQueue.push({ resolve, reject });
+                    })
+                        .then((token) => {
+                            originalRequest.headers['Authorization'] = `Bearer ${token}`;
+                            return instance(originalRequest);
+                        })
+                        .catch((err) => {
+                            return Promise.reject(err);
+                        });
+                }
+
+                originalRequest._retry = true;
+                isRefreshing = true;
+                try {
+                    const data = await authService.refreshToken();
+                    const newToken = data.accessToken || data.access_token || data.token;
+                    if (newToken) {
+                        localStorage.setItem('accessToken', newToken);
+                        instance.defaults.headers.common['Authorization'] = `Bearer ${newToken}`;
+                        processQueue(null, newToken);
+                        originalRequest.headers['Authorization'] = `Bearer ${newToken}`;
+                        return instance(originalRequest);
+                    }
+                } catch (refreshError) {
+                    processQueue(refreshError, null);
+                    localStorage.removeItem('accessToken');
+                    localStorage.removeItem('refreshToken');
+                    if (typeof window !== 'undefined' && window.location.pathname !== '/') {
+                        window.location.href = '/';
+                    }
+                    return Promise.reject(refreshError);
+                } finally {
+                    isRefreshing = false;
+                }
+            } else {
+                localStorage.removeItem('accessToken');
+                if (typeof window !== 'undefined' && window.location.pathname !== '/') {
+                    window.location.href = '/';
+                }
             }
         }
         return Promise.reject(error);


### PR DESCRIPTION
## Summary
- implement `refreshToken` in `authService`
- on 401 responses refresh the token before redirecting

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889255911fc832091ca922a32653118