### PR TITLE
Fix registration payload

### DIFF
--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -70,7 +70,8 @@ const eventService = {
 
     registerForEvent: async (eventId, userId) => {
         const response = await axiosInstance.post(`/registrations`, {
-            id: { eventId, userId }
+            eventId,
+            userId
         });
         return response.data;
     },


### PR DESCRIPTION
## Summary
- send eventId and userId directly to the /registrations endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68892ba0f9608320bc852552b02fc9cb