### PR TITLE
Fix registration payload for backend

### DIFF
--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -70,16 +70,16 @@ const eventService = {
 
     registerForEvent: async (eventId, userId) => {
         const response = await axiosInstance.post(`/registrations`, {
-            eventId,
-            userId
+            id_evento: eventId,
+            id_usuario: userId
         });
         return response.data;
     },
 
     cancelRegistration: async (eventId, userId) => {
         const response = await axiosInstance.post(`/registrations/cancel`, {
-            eventId,
-            userId
+            id_evento: eventId,
+            id_usuario: userId
         });
         return response.data;
     },


### PR DESCRIPTION
## Summary
- fix event registration body param names expected by backend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68892e4e63d083209138be166c0e22ed