### PR TITLE
Update event and registration request payloads

### DIFF
--- a/src/pages/EventsPage.jsx
+++ b/src/pages/EventsPage.jsx
@@ -156,17 +156,17 @@ const EventsPage = () => {
                 aforoMax: Number(formData.aforoMax),
                 visibilidad: formData.visibilidad ? 'PUBLICO' : 'PRIVADO'
             };
+            const withCreator = {
+                ...data,
+                creador: { id: userId }
+            };
             if (editingId) {
                 await eventService.updateEvent({
-                    ...data,
-                    id: editingId,
-                    creadorId: userId
+                    ...withCreator,
+                    id: editingId
                 });
             } else {
-                await eventService.createEvent({
-                    ...data,
-                    creadorId: userId
-                });
+                await eventService.createEvent(withCreator);
             }
             setFormOpen(false);
             setFormData({ titulo: '', descripcion: '', fechaInicio: '', fechaFin: '', lugar: '', aforoMax: '', visibilidad: true, origenTipo: 'USUARIO' });

--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -70,16 +70,17 @@ const eventService = {
 
     registerForEvent: async (eventId, userId) => {
         const response = await axiosInstance.post(`/registrations`, {
-            id_evento: eventId,
-            id_usuario: userId
+            id: { eventId, userId },
+            event: { id: eventId },
+            user: { id: userId }
         });
         return response.data;
     },
 
     cancelRegistration: async (eventId, userId) => {
         const response = await axiosInstance.post(`/registrations/cancel`, {
-            id_evento: eventId,
-            id_usuario: userId
+            eventId,
+            userId
         });
         return response.data;
     },


### PR DESCRIPTION
## Summary
- align event creation/update payloads with backend requirements
- update registration requests with full `id`, `event`, and `user` objects
- send event/user IDs correctly when cancelling a registration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889330edaac8320b5979a27d1e19e1f