### PR TITLE
Add friends landing page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Dashboard from './pages/Dashboard';
 import CalendarPage from './pages/CalendarPage';
 import EventsPage from './pages/EventsPage';
 import ProfilePage from './pages/ProfilePage';
+import FriendsPage from './pages/FriendsPage';
 
 function App() {
   const [isAuthenticated, setIsAuthenticated] = useState(
@@ -44,6 +45,10 @@ function App() {
         <Route
           path="/events"
           element={isAuthenticated ? <EventsPage /> : <Navigate to="/" />}
+        />
+        <Route
+          path="/friends"
+          element={isAuthenticated ? <FriendsPage /> : <Navigate to="/" />}
         />
         <Route
           path="/profile"

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -230,7 +230,7 @@ const Dashboard = ({ onLogout }) => {
                             { icon: Calendar, title: 'Mi Calendario', desc: 'Ver todos mis eventos programados', path: '/calendar', color: UBB_COLORS.primary },
                             { icon: CalendarDays, title: 'Explorar Eventos', desc: 'Descubre nuevas actividades', path: '/events', color: UBB_COLORS.secondary },
                             { icon: User, title: 'Mi Perfil', desc: 'Ver logros y estadísticas', path: '/profile', color: '#8B5CF6' },
-                            { icon: Users, title: 'Comunidad', desc: 'Conecta con otros estudiantes', path: '/events', color: '#10B981' }
+                            { icon: Users, title: 'Comunidad', desc: 'Conecta con otros estudiantes', path: '/friends', color: '#10B981' }
                         ].map((item, index) => (
                             <button
                                 key={index}

--- a/src/pages/FriendsPage.jsx
+++ b/src/pages/FriendsPage.jsx
@@ -1,0 +1,88 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Avatar,
+  Box,
+  Button,
+  Container,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  TextField,
+  Typography
+} from '@mui/material';
+
+function generateUsers(count = 20) {
+  const firstNames = [
+    'Ana','Pedro','Luis','Maria','Juan','Carmen','Jose','Lucia','Carlos','Sofia'
+  ];
+  const lastNames = [
+    'Gonzalez','Rodriguez','Perez','Sanchez','Martinez','Lopez','Diaz','Vargas','Rojas','Silva'
+  ];
+  const users = [];
+  for (let i = 0; i < count; i++) {
+    const first = firstNames[Math.floor(Math.random() * firstNames.length)];
+    const last = lastNames[Math.floor(Math.random() * lastNames.length)];
+    const name = `${first} ${last}`;
+    const username = `${first.toLowerCase()}.${last.toLowerCase()}${i}`;
+    users.push({ id: i + 1, name, username });
+  }
+  return users;
+}
+
+const FriendsPage = () => {
+  const [search, setSearch] = useState('');
+  const [friends, setFriends] = useState([]);
+  const users = useMemo(() => generateUsers(30), []);
+
+  const filtered = users.filter(
+    (u) =>
+      u.name.toLowerCase().includes(search.toLowerCase()) ||
+      u.username.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const addFriend = (id) => {
+    if (!friends.includes(id)) {
+      setFriends([...friends, id]);
+    }
+  };
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Encuentra nuevos amigos
+      </Typography>
+      <TextField
+        fullWidth
+        label="Buscar usuario"
+        variant="outlined"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        sx={{ mb: 3 }}
+      />
+      <List>
+        {filtered.map((user) => (
+          <ListItem
+            key={user.id}
+            secondaryAction={
+              <Button
+                variant="contained"
+                onClick={() => addFriend(user.id)}
+                disabled={friends.includes(user.id)}
+              >
+                {friends.includes(user.id) ? 'Agregado' : 'Agregar'}
+              </Button>
+            }
+          >
+            <ListItemAvatar>
+              <Avatar>{user.name.charAt(0)}</Avatar>
+            </ListItemAvatar>
+            <ListItemText primary={user.name} secondary={`@${user.username}`} />
+          </ListItem>
+        ))}
+      </List>
+    </Container>
+  );
+};
+
+export default FriendsPage;


### PR DESCRIPTION
## Summary
- add friends landing page using Material UI
- route `/friends` to the new page
- link the dashboard community quick action to the new friends page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688936d715d483208eecee4f2a20c770