### PR TITLE
Add personal events to calendar and admin edit rights

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -46,8 +46,10 @@ const Dashboard = ({ onLogout }) => {
                 ]);
 
                 setUserName(userData.nombres);
+                const createdCount = summaryData.events?.eventsCreated || 0;
+                const toAttendCount = summaryData.events?.eventsToAttend || 0;
                 setStats({
-                    eventsToAttend: summaryData.events?.eventsToAttend || 0,
+                    eventsToAttend: toAttendCount + createdCount,
                     friendsCount: summaryData.friendsCount || 0,
                     eventsAttended: summaryData.events?.eventsAttended || 0
                 });

--- a/src/pages/EventsPage.jsx
+++ b/src/pages/EventsPage.jsx
@@ -260,6 +260,9 @@ const EventsPage = () => {
                             registered={registeredIds.includes(ev.id)}
                             onRegister={handleRegister}
                             onCancel={handleCancel}
+                            editable={role === 'ADMINISTRADOR'}
+                            onEdit={openForEdit}
+                            onDelete={handleDelete}
                         />
                     ))}
                 {tab === 1 && myEvents.map((ev) => (


### PR DESCRIPTION
## Summary
- show events created by the current user in the calendar view
- allow administrators to edit or delete any active event from the main listing
- count created events in the dashboard metric for upcoming events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68893642f0d48320a7c726bc1c260b3f