### PR TITLE
Fix carousel removal after sending request

### DIFF
--- a/src/pages/FriendsPage.jsx
+++ b/src/pages/FriendsPage.jsx
@@ -336,6 +336,9 @@ const FriendsPage = () => {
     setActionLoading((prev) => ({ ...prev, [friendId]: true }));
     try {
       await userService.sendFriendRequest(userId, friendId);
+      // Quitamos la recomendaci\u00f3n localmente antes de refrescar
+      setRecommendations((prev) => prev.filter((u) => u.id !== friendId));
+
       const recPromise = userService
         .getRecommendations(userId)
         .catch((err) => {
@@ -350,7 +353,7 @@ const FriendsPage = () => {
         });
 
       const [rec, pend] = await Promise.all([recPromise, pendPromise]);
-      if (rec) setRecommendations(rec);
+      if (rec) setRecommendations(rec.filter((u) => u.id !== friendId));
       if (pend) setPending(pend);
     } catch (err) {
       console.error('Error sending friend request:', err);

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -23,7 +23,13 @@ const userService = {
     },
     getPendingFriendRequests: async (userId) => {
         const res = await axiosInstance.get(`/friendships/pending/${userId}`);
-        return res.data;
+        const data = res.data || [];
+        // API devuelve objetos de amistad con user1 y user2
+        // Filtramos para obtener solo las solicitudes donde el usuario actual
+        // es el receptor (user2)
+        return data
+            .filter((f) => f.user2 && f.user2.id === userId && f.user1)
+            .map((f) => f.user1);
     },
     getFriends: async (userId) => {
         const res = await axiosInstance.get(`/friendships/friends/${userId}`);


### PR DESCRIPTION
## Summary
- remove sent friend from carousel even when refreshing data
- filter pending friend requests so only incoming requests appear

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68895f7b9d9c8320bac7ac043c335184