### PR TITLE
Fix public events visibility

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -42,7 +42,7 @@ const Dashboard = ({ onLogout }) => {
                 const [userData, summaryData, eventsData] = await Promise.all([
                     userService.getUser(userId),
                     userService.getSummary(userId),
-                    eventService.getUpcomingEvents()
+                    eventService.getPublicEvents()
                 ]);
 
                 setUserName(userData.nombres);

--- a/src/pages/EventsPage.jsx
+++ b/src/pages/EventsPage.jsx
@@ -410,7 +410,7 @@ const EventsPage = () => {
                 setRole(userRole);
                 setUserId(uid);
 
-                const all = await eventService.getUpcomingEvents();
+                const all = await eventService.getPublicEvents();
                 setEvents(all.sort((a, b) => new Date(a.fechaInicio) - new Date(b.fechaInicio)));
                 setPage(1);
 
@@ -434,7 +434,7 @@ const EventsPage = () => {
     }, []);
 
     const refreshAll = async () => {
-        const all = await eventService.getUpcomingEvents();
+        const all = await eventService.getPublicEvents();
         setEvents(all.sort((a, b) => new Date(a.fechaInicio) - new Date(b.fechaInicio)));
         setPage(1);
         if (userId) {

--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -87,7 +87,11 @@ const eventService = {
 
     getPublicEvents: async () => {
         const response = await axiosInstance.get(`/events/public`);
-        return response.data;
+        const events = response.data || [];
+        const now = new Date();
+        return events
+            .filter(ev => new Date(ev.fechaFin) >= now)
+            .sort((a, b) => new Date(a.fechaInicio) - new Date(b.fechaInicio));
     },
 
     clearUpcomingCache: () => {


### PR DESCRIPTION
## Summary
- show events approved as public using `getPublicEvents`
- display public events on dashboard
- filter out expired public events and sort them by date

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68895c7380d08320b24340aa1ce02f40