### PR TITLE
Fix closing ticket modal

### DIFF
--- a/src/pages/TicketsPage.jsx
+++ b/src/pages/TicketsPage.jsx
@@ -25,16 +25,18 @@ const TicketsPage = () => {
         load();
     }, []);
 
-    const handleClose = async (id) => {
+    const handleClose = async () => {
+        if (!selected) return;
+        const id = selected.id;
+        setClosing(true);
         try {
-            setClosing(true);
             await ticketService.closeTicket(id);
-            setTickets(tickets.filter(t => t.id !== id));
-            setSelected(null);
+            setTickets(prev => prev.filter(t => t.id !== id));
         } catch (err) {
             console.error('Error closing ticket', err);
         } finally {
             setClosing(false);
+            setSelected(null);
         }
     };
 
@@ -105,7 +107,7 @@ const TicketsPage = () => {
                             >Cerrar</button>
                             <button
                                 style={{ ...styles.button, backgroundColor:UBB_COLORS.primary, color:'white' }}
-                                onClick={() => handleClose(selected.id)}
+                                onClick={handleClose}
                                 disabled={closing}
                             >{closing ? 'Cerrando...' : 'Marcar como resuelto'}</button>
                         </div>


### PR DESCRIPTION
## Summary
- fix `handleClose` to use selected ticket internally
- close modal when ticket is resolved

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688982991f5083209bdb8a50b41bbb92